### PR TITLE
[minor] added support for custom HTTP handlers in probe server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![](https://github.com/naughtygopher/proberesponder/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/naughtygopher/proberesponder/actions)
 [![Go Reference](https://pkg.go.dev/badge/github.com/naughtygopher/proberesponder.svg)](https://pkg.go.dev/github.com/naughtygopher/proberesponder)
-[![Go Report Card](https://goreportcard.com/badge/github.com/naughtygopher/proberesponder?cache_invalidate=v0.4.0)](https://goreportcard.com/report/github.com/naughtygopher/proberesponder)
-[![Coverage Status](https://coveralls.io/repos/github/naughtygopher/proberesponder/badge.svg?branch=main&cache_invalidate=v0.4.0)](https://coveralls.io/github/naughtygopher/proberesponder?branch=main)
+[![Go Report Card](https://goreportcard.com/badge/github.com/naughtygopher/proberesponder?cache_invalidate=v0.5.0)](https://goreportcard.com/report/github.com/naughtygopher/proberesponder)
+[![Coverage Status](https://coveralls.io/repos/github/naughtygopher/proberesponder/badge.svg?branch=main&cache_invalidate=v0.5.0)](https://coveralls.io/github/naughtygopher/proberesponder?branch=main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/creativecreature/sturdyc/blob/master/LICENSE)
 
 # Proberesponder

--- a/extensions/http/http_test.go
+++ b/extensions/http/http_test.go
@@ -388,6 +388,17 @@ func Test_contentNeogiater(t *testing.T) {
 	}
 }
 
+func TestCustomHandler(tt *testing.T) {
+	expectedResponse := "success"
+	srv := Server(proberesponder.New(), "", 1234, Handlers{http.MethodGet, "/mypath", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(expectedResponse))
+	}})
+	req, _ := http.NewRequest(http.MethodGet, "/mypath", nil)
+	w := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(w, req)
+	assert.Equal(tt, expectedResponse, w.Body.String())
+}
+
 func httpReq(acceptType string) *http.Request {
 	req, _ := http.NewRequest(http.MethodGet, "http://localhost:1234", nil)
 	req.Header.Add(httpHeaderAccept, acceptType)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/naughtygopher/proberesponder
 
-go 1.23.3
+go 1.18
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
- the probe responder HTTP server can be used to handle other auxiliary metadata of the application or statuses