### PR TITLE
[patch] execute probe immediately to avoid waiting for the first tick

### DIFF
--- a/extensions/depprober/depprober.go
+++ b/extensions/depprober/depprober.go
@@ -124,6 +124,7 @@ func Start(
 	*/
 	tick := time.NewTicker(delay)
 	go func() {
+        probe(delay, pstatus, pingers...)
 		for range tick.C {
 			probe(delay, pstatus, pingers...)
 		}


### PR DESCRIPTION
hi @bnkamalesh  When the application starts for the first time, probe execution currently waits for the first tick. If the tick interval is set to 1 minute, the probes will only be executed after that first minute has passed. As a result, during this initial period all probes are reported as OK, even though no actual checks have been performed yet. By executing the probes immediately on startup, the probe status can reflect the real condition right away without waiting for the first tick, providing more accurate initial feedback and better observability.